### PR TITLE
🔧 Test latest-changes skip labels branch

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         limit-access-to-actor: true
     # - uses: docker://tiangolo/latest-changes:latest
-    - uses: tiangolo/latest-changes@0.4.1
+    - uses: tiangolo/latest-changes@skip-labels
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         latest_changes_file: docs/en/docs/release-notes.md
@@ -43,6 +43,7 @@ jobs:
         template_file: ./.github/workflows/release-notes.jinja2
         end_regex: '^## '
         debug_logs: true
+        skip_labels: '["release"]'
         labels: >
           [
             {"label": "breaking", "header": "### Breaking Changes"},


### PR DESCRIPTION
Switch the sandbox latest-changes workflow to the skip-labels branch from tiangolo/latest-changes#96 and configure the release skip label.