### PR TITLE
👷 Fix alls-green test dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
     if: always()
     needs:
       - coverage-combine
+      - test
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed


### PR DESCRIPTION
## Summary
- Add the main test job to the alls-green needs list.
- Ensure the required aggregate check sees direct test failures, not only downstream coverage status.

## Root cause
The alls-green job did not depend directly on the primary test job, so the JSON passed to re-actors/alls-green omitted that job's status.

## Validation
- Parsed .github/workflows/test.yml with PyYAML and asserted the alls-green job needs includes the primary test job.

## AI Disclaimer
Codex GPT 5.5, reviewed by hand.
