### PR TITLE
👷 Update issue-manager to 0.7.1

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -22,7 +22,7 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@master
+      - uses: tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >


### PR DESCRIPTION
## Changes

Updates the Issue Manager workflow to pin `tiangolo/issue-manager` to the released `0.7.1` commit instead of `master`.

## Validation

- `git diff --check`
- `uvx prek run --files .github/workflows/issue-manager.yml`

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
