### PR TITLE
👷 Fix notify translations checkout target

### DIFF
--- a/.github/workflows/notify-translations.yml
+++ b/.github/workflows/notify-translations.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       # Allow debugging with tmate
       - name: Setup tmate session


### PR DESCRIPTION
## What changed

- Configure the `notify-translations` workflow checkout step to use the repository default branch explicitly.
- This keeps `pull_request_target` runs on trusted base-repository code when `actions/checkout@v7` is used.

## Why

`actions/checkout@v7` refuses fork PR code in trusted `pull_request_target` contexts. The workflow only needs trusted repository code to run the notification script/action.

## Validation

- Ran `git diff --check` for the changed workflow.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
