### PR TITLE
⬆️ Update PR Push

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Get PR Push token
         id: pr-push
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
-        uses: tiangolo/pr-push@ac6dc2788c46c12d45553e020fc75de30d30c312
+        uses: tiangolo/pr-push@e84e947b8cd4b6ee30e5c43e817f78ec2fdf9ae7
         with:
           url: https://pr-push-dev.fastapicloud.dev
       - name: Commit and push changes


### PR DESCRIPTION
## Description

Update the pinned PR Push Action commit to include the Docker import fix.

GitHub runs Docker Actions from `/github/workspace`; the new image explicitly makes `/app/pr_push` importable.

## AI Disclaimer

This PR was created with OpenAI Codex using GPT-5.6-sol and reviewed by hand.

## Validation

- Repository pre-commit checks pass for the workflow file.
