### PR TITLE
🔧 Use token committer

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,8 +72,6 @@ jobs:
         env:
           PR_PUSH_TOKEN: ${{ steps.pr-push.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${PR_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add -A
           git commit -m "🎨 Auto format"


### PR DESCRIPTION
## Description

Stop explicitly configuring `github-actions[bot]` as the committer before pushing pre-commit fixes with the PR Push installation token.

This workflow-only change must be merged before a separate formatting PR can exercise the trusted workflow and show which identity Git uses without configuration.

## AI Disclaimer

This PR was created with OpenAI Codex using GPT-5.6-sol and reviewed by hand.

## Validation

- Repository pre-commit checks pass for the workflow file.
