### PR TITLE
🔧 Restore GitHub Actions committer

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,6 +72,8 @@ jobs:
         env:
           PR_PUSH_TOKEN: ${{ steps.pr-push.outputs.token }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${PR_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add -A
           git commit -m "🎨 Auto format"


### PR DESCRIPTION
## Description

Restore `github-actions[bot]` as the explicit author for pre-commit formatting commits.

The installation token authenticates the push but does not supply Git's required commit identity.

## AI Disclaimer

This PR was created with OpenAI Codex using GPT-5.6-sol and reviewed by hand.

## Validation

- Repository pre-commit checks pass for the workflow file.
- The no-identity experiment failed with `Author identity unknown`, confirming the configuration is required.
