### PR TITLE
🧪 Test modified workflow rejection

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,6 +61,7 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
+      # A pull request must not be able to modify this workflow and receive a token.
       - name: Get PR Push token
         id: pr-push
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'

--- a/checkable.txt
+++ b/checkable.txt
@@ -1,1 +1,1 @@
-checkable
+Test modified workflow rejection


### PR DESCRIPTION
## Description

Exercise PR Push's modified-workflow rejection with a harmless comment-only workflow change and an intentional formatting issue.

The workflow should reach the token step, but `pr-push-dev` must return HTTP 403 because the executed workflow differs from the trusted version on the pull request's base commit. No installation token should be returned or pushed.

This security-test PR is expected to have a failing pre-commit check and will be closed without merging after verification.

## AI Disclaimer

This PR was created with OpenAI Codex using GPT-5.6-sol and reviewed by hand.

## Validation

- [ ] PR Push rejects the request with HTTP 403.
- [ ] FastAPI Cloud logs report `workflow differs from the trusted version`.
- [ ] No formatting commit is pushed.
- [ ] Workflow logs expose no token.
