### PR TITLE
🧪 Test PR Push development endpoint

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -65,6 +65,8 @@ jobs:
         id: pr-push
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
         uses: tiangolo/pr-push@0.0.1
+        with:
+          url: https://pr-push-dev.fastapicloud.dev
       - name: Commit and push changes
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
         env:


### PR DESCRIPTION
## Summary

Temporarily point the sandbox pre-commit workflow to the PR Push development deployment so the new workflow-write permission can be tested before production deployment.

## AI Disclaimer

This PR was created with `gpt-5.6-sol` and reviewed by hand.
