### PR TITLE
🧪 Restore PR Push production endpoint

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -65,8 +65,6 @@ jobs:
         id: pr-push
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
         uses: tiangolo/pr-push@0.0.1
-        with:
-          url: https://pr-push-dev.fastapicloud.dev
       - name: Commit and push changes
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
         env:


### PR DESCRIPTION
## Summary

Restore the sandbox pre-commit workflow to the default PR Push production endpoint after validating the development deployment.

## AI Disclaimer

This PR was created with `gpt-5.6-sol` and reviewed by hand.
