### PR TITLE
🧪 Test PR Submit development endpoint

### DIFF
--- a/.github/pr-submit.yml
+++ b/.github/pr-submit.yml
@@ -1,0 +1,2 @@
+workflows:
+  - .github/workflows/prepare-release.yml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,9 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
+      id-token: write
     env:
       PREPARE_RELEASE_VERSION_FILE: app/__init__.py
       PREPARE_RELEASE_RELEASE_NOTES_FILE: docs/en/docs/release-notes.md
@@ -36,7 +35,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -57,9 +56,14 @@ jobs:
           version="$(uv run python scripts/prepare_release.py current-version)"
           echo "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Get PR Submit token
+        id: pr-submit
+        uses: tiangolo/pr-submit@main
+        with:
+          url: https://pr-submit-dev.fastapicloud.dev
       - name: Create release pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.pr-submit.outputs.token }}
           VERSION: ${{ steps.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
@@ -69,5 +73,11 @@ jobs:
           git switch -c "$branch"
           git add $PREPARE_RELEASE_VERSION_FILE $PREPARE_RELEASE_RELEASE_NOTES_FILE
           git commit -m "🔖 Release version ${VERSION}"
+          gh auth setup-git
           git push --set-upstream origin "$branch"
-          gh pr create             --base master             --head "$branch"             --title "🔖 Release version ${VERSION}"             --body "Prepare release ${VERSION}."             --label release
+          gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "🔖 Release version ${VERSION}" \
+            --body "Prepare release ${VERSION}." \
+            --label release


### PR DESCRIPTION
## Summary

- allow the sandbox release workflow to request PR Submit tokens
- use the PR Submit development service for the end-to-end test
- remove the default GitHub token from checkout and PR creation

After this workflow is merged into `master`, it can be dispatched to create a real release PR with a repository-scoped `pr-submit-dev[bot]` token.

## Checks

- validated both YAML files
- ran `git diff --check`

## AI Disclaimer

This PR was created with the help of gpt-5.6-sol and reviewed by hand.
