### PR TITLE
🧪 Test PR Submit production endpoint

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -58,9 +58,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Get PR Submit token
         id: pr-submit
-        uses: tiangolo/pr-submit@main
-        with:
-          url: https://pr-submit-dev.fastapicloud.dev
+        uses: tiangolo/pr-submit@d802fdf59bde80bc3eb8bd3259f4cbeec63de4aa # 0.0.1
       - name: Create release pull request
         env:
           GH_TOKEN: ${{ steps.pr-submit.outputs.token }}


### PR DESCRIPTION
## Summary

- pin PR Submit to the immutable 0.0.1 release commit
- use the Action's default production service URL

After this is merged into `master`, the release workflow will exercise the production GitHub App and FastAPI Cloud deployment.

## Checks

- validated the workflow YAML
- ran `git diff --check`

## AI Disclaimer

This PR was created with the help of gpt-5.6-sol and reviewed by hand.
