### PR TITLE
👷 Use GitHub CLI for Git authentication

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Commit and push changes
         if: env.IS_FORK == 'false' && steps.changes.outputs.changed == 'true'
         env:
-          PR_PUSH_TOKEN: ${{ steps.pr-push.outputs.token }}
+          GH_TOKEN: ${{ steps.pr-push.outputs.token }}
         run: |
           git config user.name "pr-push[bot]"
           git config user.email "pr-push[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${PR_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          gh auth setup-git
           git add -A
           git commit -m "🎨 Auto format"
           git push


### PR DESCRIPTION
## Summary

- expose the short-lived PR Push token as `GH_TOKEN`
- configure Git authentication with `gh auth setup-git`
- avoid embedding the token in the repository remote URL

## Checks

- parsed `.github/workflows/pre-commit.yml` as YAML
- `git diff --check`

## AI Disclaimer

This PR was created with the help of gpt-5.6-sol and reviewed by hand.
